### PR TITLE
Intermediate step for enabling separate gecko window (QWindow)

### DIFF
--- a/quick/mainqt5.cpp
+++ b/quick/mainqt5.cpp
@@ -9,6 +9,8 @@
 
 int main(int argc, char **argv)
 {
+    setenv("MOZ_LAYERS_PREFER_OFFSCREEN", "1", 1);
+
     QGuiApplication app(argc, argv);
     app.setQuitOnLastWindowClosed(true);
 


### PR DESCRIPTION
In order to get chrome window and gecko window working together
we don't want gecko to prefer offscreen.
